### PR TITLE
Rename stash to bitbucket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ And here's another example how to get issues from Jira using JQL Query:
     data = jira.jql(JQL)
     print(data)
 
-Plasease make sure, you've checked ``examples/`` directory on how to build scripts using the API.
+Please make sure, you've checked ``examples/`` directory on how to build scripts using the API.
 
 
 For Contributors

--- a/atlassian/__init__.py
+++ b/atlassian/__init__.py
@@ -1,7 +1,8 @@
 from .confluence import Confluence
 from .jira import Jira
-from .stash import Stash
+from .bitbucket import Bitbucket
+from .bitbucket import Bitbucket as Stash
 from .portfolio import Portfolio
 from .bamboo import Bamboo
 
-__all__ = ['Confluence', 'Jira', 'Stash', 'Portfolio', 'Bamboo']
+__all__ = ['Confluence', 'Jira', 'Bitbucket', 'Portfolio', 'Bamboo', 'Stash']

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -2,10 +2,10 @@ import logging
 from .rest_client import AtlassianRestAPI
 
 
-log = logging.getLogger('atlassian.stash')
+log = logging.getLogger(__name__)
 
 
-class Stash(AtlassianRestAPI):
+class Bitbucket(AtlassianRestAPI):
 
     def project_list(self):
         return self.get('/rest/api/1.0/projects')['values']
@@ -79,7 +79,7 @@ class Stash(AtlassianRestAPI):
         return self.get(url)['diffs']
 
     def get_commits(self, project, repository, hash_oldest, hash_newest, limit=99999):
-        url = '/rest/api/1.0/projects/{project}/repos/{repository}/commits?since={hash_oldest}&until={hash_newest}&limit={limit}'.format(
+        url = '/rest/api/1.0/projects/{project}/repos/{repository}/commits?since={hash_from}&until={hash_to}&limit={limit}'.format(
             project=project,
             repository=repository,
             hash_from=hash_oldest,

--- a/examples/bitbucket-changes-between-branches.py
+++ b/examples/bitbucket-changes-between-branches.py
@@ -1,11 +1,11 @@
-from atlassian import Stash
+from atlassian import Bitbucket
 
-stash = Stash(
+bitbucket = Bitbucket(
     url='http://localhost:7990',
     username='admin',
     password='admin')
 
-changelog = stash.get_changelog(
+changelog = bitbucket.get_changelog(
     project='DEMO',
     repository='example-repository',
     ref_from='develop',

--- a/examples/bitbucket-project.py
+++ b/examples/bitbucket-project.py
@@ -1,5 +1,5 @@
 from pprint import pprint
-from atlassian import Stash
+from atlassian import Bitbucket
 
 
 def html(project):
@@ -8,10 +8,11 @@ def html(project):
         html += '\n\t<li><a href="mailto:{email}">{name}</a></li>'.format(**user)
     return html + '</ul></td></tr>\n'
 
-stash = Stash(
+bitbucket = Bitbucket(
     url='http://localhost:7990',
     username='admin',
     password='admin')
 
-data = stash.project('DEMO')
+data = bitbucket.project('DEMO')
 pprint(html(data))
+

--- a/examples/bitbucket-projects-administrators.py
+++ b/examples/bitbucket-projects-administrators.py
@@ -1,19 +1,19 @@
 import logging
-from atlassian import Stash
+from atlassian import Bitbucket
 
 
 logging.basicConfig(level=logging.DEBUG, format='[%(asctime).19s] [%(levelname)s] %(message)s')
 logging.getLogger('requests').setLevel(logging.WARNING)
-log = logging.getLogger('stash-projects-administrators')
+log = logging.getLogger('bitbucket-projects-administrators')
 
-stash = Stash(
+bitbucket = Bitbucket(
     url='http://localhost:7990',
     username='admin',
     password='admin')
 
 html = '<table><tr><th>Project Key</th><th>Project Name</th><th>Administrator</th></tr>'
 
-for data in stash.all_project_administrators():
+for data in bitbucket.all_project_administrators():
     html += '<tr><td>{project_key}</td><td>{project_name}</td><td><ul>'.format(**data)
     for user in data['project_administrators']:
         html += '<li><a href="mailto:{email}">{name}</a></li>'.format(**user)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,4 @@
-from atlassian import Jira, Confluence, Stash, Portfolio, Bamboo
+from atlassian import Jira, Confluence, Bitbucket, Portfolio, Bamboo
 import os
 
 
@@ -27,8 +27,8 @@ class TestBasic(object):
             password=ATLASSIAN_PASSWORD
         )
 
-    def test_init_stash(self):
-        stash = Stash(
+    def test_init_bitbucket(self):
+        bitbucket = Bitbucket(
             url=STASH_URL,
             username=ATLASSIAN_USER,
             password=ATLASSIAN_PASSWORD


### PR DESCRIPTION
Since Stash has been renamed to Bitbucket long time ago, it probably makes sense to rename the classes. For backwards compatibility, the 'new' Bitbucket class is also being imported as 'Stash'