### PR TITLE
Add support for parent_id set as Null

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -31,16 +31,19 @@ class Confluence(AtlassianRestAPI):
         url = '/rest/api/content/{page_id}?expand={expand}'.format(page_id=page_id, expand=expand)
         return self.get(url)
 
-    def create_page(self, space, parent_id, title, body, type='page'):
+    def create_page(self, space, title, body, parent_id = None, type='page'):
         log.info('Creating {type} "{space}" -> "{title}"'.format(space=space, title=title, type=type))
-        return self.post('/rest/api/content/', data={
+        data={
             'type': type,
-            'ancestors': [{'type': type, 'id': parent_id}],
             'title': title,
             'space': {'key': space},
             'body': {'storage': {
                 'value': body,
-                'representation': 'storage'}}})
+                'representation': 'storage'}}}
+        if parent_id:
+            data['ancestors'] = [{'type': type, 'id': parent_id}]
+        return self.post('rest/api/content/', data = data)
+
 
     def history(self, page_id):
         return self.get('/rest/api/content/{0}/history'.format(page_id))


### PR DESCRIPTION
The documentation does not work as `parent_id` cannot be set as null.
This changes the method signature, so I do not know if that is fine with you.

```
status = confluence.create_page(
    space='DEMO',
    title='This is the title',
    body='This is the body. You can use <strong>HTML tags</strong>!')
```
This PR allows for `parent_id` being `None`.

Also `self.get('/rest/api/...` does not allow for server URLs of the format 
```
https://company.atlassian.net/wiki/
```
as the forward slash at the beginning  results here: https://github.com/AstroMatt/atlassian-python-api/blob/81b940d5859cf9dc311fa4e006ded0ea3d8aabe8/atlassian/rest_client.py#L42
to truncate the URL to `https://company.atlassian.net/` and loose the `/wiki`