### PR TITLE
Add convert_wiki_to_storage function to Confluence

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -218,3 +218,8 @@ class Confluence(AtlassianRestAPI):
             url=result['_links']['tinyui']))
 
         return result
+
+    def convert_wiki_to_storage(self, wiki):
+        data = { 'value': wiki,
+                 'representation': 'wiki' }
+        return self.post('rest/api/contentbody/convert/storage', data=data)


### PR DESCRIPTION
The Confluence REST API now allows access to the body content
convertion functions. Particularly useful when you want to upload wiki
format to Confluence.