### PR TITLE
Make more comfortable get_page_id behaviour

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -58,7 +58,7 @@ class Confluence(AtlassianRestAPI):
         :param title: title
         :return:
         """
-        return self.get_page_by_title(space, title).get('id')
+        return (self.get_page_by_title(space, title) or {}).get('id')
 
     def get_page_space(self, page_id):
         """


### PR DESCRIPTION
If get_pade_id exec with wrong id parameter, don't raise 'AttributeError: 'NoneType' object has no attribute 'get''